### PR TITLE
Fixing NPE issue in case custom module does binder.requestInjection

### DIFF
--- a/polyguice-core/src/main/java/com/flipkart/polyguice/core/support/LifecycleManager.java
+++ b/polyguice-core/src/main/java/com/flipkart/polyguice/core/support/LifecycleManager.java
@@ -64,6 +64,7 @@ class LifecycleManager {
         procNames = new ArrayList<>();
         singletonKeys = new ArrayList<>();
         disposables = new ArrayList<>();
+        processors = new ArrayList<>();
     }
 
     public void setProcessors(List<String> names) {
@@ -89,7 +90,6 @@ class LifecycleManager {
     public boolean start() {
         LOGGER.debug("starting lifecycle operations");
         startupError = false;
-        processors = new ArrayList<>();
         for(String name : procNames) {
             ComponentProcessor proc = (ComponentProcessor)
                     compCtxt.getInstance(name);


### PR DESCRIPTION
When CustomModule does requestInjection, the following happens:
1. Polyguice attempts Guice.createInjector against PolyguiceModule and CustomModule
2. PolyguiceModule - will init LifecycleManager variable with processors = null
3. CustomModule - does requestInjection that will trigger LifecycleManager.InjectionHandler#afterInjection(Object component)
4. At this point since LifecycleManager#start() was not invoked, processors = null, hence we get NPE

To fix the issue, the commit initializes processors = new ArrayList<>() to empty list in the constructor.
