### PR TITLE
This enables us to provide configurations in the form of URLs

### DIFF
--- a/polyguice-akka/pom.xml
+++ b/polyguice-akka/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.flipkart.polyguice</groupId>
         <artifactId>polyguice-all</artifactId>
-        <version>1.0.3</version>
+        <version>1.0.2-SNAPSHOT.patched</version>
     </parent>
 
     <artifactId>polyguice-akka</artifactId>

--- a/polyguice-akka/pom.xml
+++ b/polyguice-akka/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.flipkart.polyguice</groupId>
         <artifactId>polyguice-all</artifactId>
-        <version>1.0.2-SNAPSHOT</version>
+        <version>1.0.2-SNAPSHOT.patched</version>
     </parent>
 
     <artifactId>polyguice-akka</artifactId>

--- a/polyguice-akka/pom.xml
+++ b/polyguice-akka/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.flipkart.polyguice</groupId>
         <artifactId>polyguice-all</artifactId>
-        <version>1.0.2-SNAPSHOT.patched</version>
+        <version>1.0.3</version>
     </parent>
 
     <artifactId>polyguice-akka</artifactId>

--- a/polyguice-akka/pom.xml
+++ b/polyguice-akka/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.flipkart.polyguice</groupId>
         <artifactId>polyguice-all</artifactId>
-        <version>1.0.2-SNAPSHOT.patched</version>
+        <version>1.0.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>polyguice-akka</artifactId>

--- a/polyguice-config/pom.xml
+++ b/polyguice-config/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.flipkart.polyguice</groupId>
         <artifactId>polyguice-all</artifactId>
-        <version>1.0.3</version>
+        <version>1.0.2-SNAPSHOT.patched</version>
     </parent>
 
     <artifactId>polyguice-config</artifactId>

--- a/polyguice-config/pom.xml
+++ b/polyguice-config/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.flipkart.polyguice</groupId>
         <artifactId>polyguice-all</artifactId>
-        <version>1.0.2-SNAPSHOT.patched</version>
+        <version>1.0.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>polyguice-config</artifactId>

--- a/polyguice-config/pom.xml
+++ b/polyguice-config/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.flipkart.polyguice</groupId>
         <artifactId>polyguice-all</artifactId>
-        <version>1.0.2-SNAPSHOT</version>
+        <version>1.0.2-SNAPSHOT.patched</version>
     </parent>
 
     <artifactId>polyguice-config</artifactId>

--- a/polyguice-config/pom.xml
+++ b/polyguice-config/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.flipkart.polyguice</groupId>
         <artifactId>polyguice-all</artifactId>
-        <version>1.0.2-SNAPSHOT.patched</version>
+        <version>1.0.3</version>
     </parent>
 
     <artifactId>polyguice-config</artifactId>

--- a/polyguice-core/pom.xml
+++ b/polyguice-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.flipkart.polyguice</groupId>
         <artifactId>polyguice-all</artifactId>
-        <version>1.0.2-SNAPSHOT.patched</version>
+        <version>1.0.3</version>
     </parent>
 
     <artifactId>polyguice-core</artifactId>

--- a/polyguice-core/pom.xml
+++ b/polyguice-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.flipkart.polyguice</groupId>
         <artifactId>polyguice-all</artifactId>
-        <version>1.0.2-SNAPSHOT</version>
+        <version>1.0.2-SNAPSHOT.patched</version>
     </parent>
 
     <artifactId>polyguice-core</artifactId>

--- a/polyguice-core/pom.xml
+++ b/polyguice-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.flipkart.polyguice</groupId>
         <artifactId>polyguice-all</artifactId>
-        <version>1.0.3</version>
+        <version>1.0.2-SNAPSHOT.patched</version>
     </parent>
 
     <artifactId>polyguice-core</artifactId>

--- a/polyguice-core/pom.xml
+++ b/polyguice-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.flipkart.polyguice</groupId>
         <artifactId>polyguice-all</artifactId>
-        <version>1.0.2-SNAPSHOT.patched</version>
+        <version>1.0.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>polyguice-core</artifactId>

--- a/polyguice-dropwiz/pom.xml
+++ b/polyguice-dropwiz/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.flipkart.polyguice</groupId>
         <artifactId>polyguice-all</artifactId>
-        <version>1.0.2-SNAPSHOT</version>
+        <version>1.0.2-SNAPSHOT.patched</version>
     </parent>
 
     <artifactId>polyguice-dropwiz</artifactId>

--- a/polyguice-dropwiz/pom.xml
+++ b/polyguice-dropwiz/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.flipkart.polyguice</groupId>
         <artifactId>polyguice-all</artifactId>
-        <version>1.0.3</version>
+        <version>1.0.2-SNAPSHOT.patched</version>
     </parent>
 
     <artifactId>polyguice-dropwiz</artifactId>

--- a/polyguice-dropwiz/pom.xml
+++ b/polyguice-dropwiz/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.flipkart.polyguice</groupId>
         <artifactId>polyguice-all</artifactId>
-        <version>1.0.2-SNAPSHOT.patched</version>
+        <version>1.0.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>polyguice-dropwiz</artifactId>

--- a/polyguice-dropwiz/pom.xml
+++ b/polyguice-dropwiz/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.flipkart.polyguice</groupId>
         <artifactId>polyguice-all</artifactId>
-        <version>1.0.2-SNAPSHOT.patched</version>
+        <version>1.0.3</version>
     </parent>
 
     <artifactId>polyguice-dropwiz</artifactId>

--- a/polyguice-web/pom.xml
+++ b/polyguice-web/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.flipkart.polyguice</groupId>
         <artifactId>polyguice-all</artifactId>
-        <version>1.0.2-SNAPSHOT.patched</version>
+        <version>1.0.3</version>
     </parent>
 
     <artifactId>polyguice-web</artifactId>

--- a/polyguice-web/pom.xml
+++ b/polyguice-web/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.flipkart.polyguice</groupId>
         <artifactId>polyguice-all</artifactId>
-        <version>1.0.3</version>
+        <version>1.0.2-SNAPSHOT.patched</version>
     </parent>
 
     <artifactId>polyguice-web</artifactId>

--- a/polyguice-web/pom.xml
+++ b/polyguice-web/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.flipkart.polyguice</groupId>
         <artifactId>polyguice-all</artifactId>
-        <version>1.0.2-SNAPSHOT.patched</version>
+        <version>1.0.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>polyguice-web</artifactId>

--- a/polyguice-web/pom.xml
+++ b/polyguice-web/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.flipkart.polyguice</groupId>
         <artifactId>polyguice-all</artifactId>
-        <version>1.0.2-SNAPSHOT</version>
+        <version>1.0.2-SNAPSHOT.patched</version>
     </parent>
 
     <artifactId>polyguice-web</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <artifactId>polyguice-all</artifactId>
     <name>Polyguice</name>
     <packaging>pom</packaging>
-    <version>1.0.2-SNAPSHOT.patched</version>
+    <version>1.0.3</version>
 
     <scm>
         <url>https://github.com/flipkart-incubator/polyguice.git</url>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <artifactId>polyguice-all</artifactId>
     <name>Polyguice</name>
     <packaging>pom</packaging>
-    <version>1.0.3</version>
+    <version>1.0.2-SNAPSHOT.patched</version>
 
     <scm>
         <url>https://github.com/flipkart-incubator/polyguice.git</url>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <artifactId>polyguice-all</artifactId>
     <name>Polyguice</name>
     <packaging>pom</packaging>
-    <version>1.0.2-SNAPSHOT.patched</version>
+    <version>1.0.3-SNAPSHOT</version>
 
     <scm>
         <url>https://github.com/flipkart-incubator/polyguice.git</url>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <artifactId>polyguice-all</artifactId>
     <name>Polyguice</name>
     <packaging>pom</packaging>
-    <version>1.0.2-SNAPSHOT</version>
+    <version>1.0.2-SNAPSHOT.patched</version>
 
     <scm>
         <url>https://github.com/flipkart-incubator/polyguice.git</url>

--- a/release.sh
+++ b/release.sh
@@ -2,4 +2,4 @@
 set -e
 set -x
 mvn clean install
-mvn deploy -DskipTests -DaltDeploymentRepository=clojars::default::https://clojars.org/repo
+mvn deploy -DperformRelease=true -DskipTests -DaltDeploymentRepository=clojars::default::https://clojars.org/repo


### PR DESCRIPTION
The initial path based configurations prevented us from accessing resources that are,say, packaged within a jar
Since the underlying configuration impls accept both files and urls, this should not be a breaking change and we end up exposing similar functionality throughout
